### PR TITLE
bugfix - empty dataframe period error

### DIFF
--- a/eia/generators/boson/provider.py
+++ b/eia/generators/boson/provider.py
@@ -167,10 +167,13 @@ class EIAGenerators:
 
         # Create the dataframe from the results
         data = response.get("data", [])
-        gdf = gpd.GeoDataFrame(data)
-        gdf.loc[:, "period"] = pd.to_datetime(gdf.period, utc=True)
-        geometry_column = gpd.points_from_xy(gdf.longitude, gdf.latitude)
-        gdf = gpd.GeoDataFrame(gdf, geometry=geometry_column)
+        if data:
+            gdf = gpd.GeoDataFrame(data)
+            gdf.loc[:, "period"] = pd.to_datetime(gdf.period, utc=True)
+            geometry_column = gpd.points_from_xy(gdf.longitude, gdf.latitude)
+            gdf = gpd.GeoDataFrame(gdf, geometry=geometry_column)
+        else:
+            return gpd.GeoDataFrame(), {}
 
         return gdf, {"token": pagination.get_next_token(offset + len(gdf))}
 


### PR DESCRIPTION
- if response was valid but empty, we were creating a gdf and looking for the "period" column, causing an error
- now, we simply return an empty gdf