### PR TITLE
Bugfix/datatypes

### DIFF
--- a/eia/generators/boson/provider.py
+++ b/eia/generators/boson/provider.py
@@ -167,10 +167,13 @@ class EIAGenerators:
 
         # Create the dataframe from the results
         data = response.get("data", [])
-        gdf = gpd.GeoDataFrame(data)
-        gdf.loc[:, "period"] = pd.to_datetime(gdf.period, utc=True)
-        geometry_column = gpd.points_from_xy(gdf.longitude, gdf.latitude)
-        gdf = gpd.GeoDataFrame(gdf, geometry=geometry_column)
+        if data:
+            gdf = gpd.GeoDataFrame(data)
+            gdf.loc[:, "period"] = pd.to_datetime(gdf.period, utc=True)
+            geometry_column = gpd.points_from_xy(gdf.longitude, gdf.latitude)
+            gdf = gpd.GeoDataFrame(gdf, geometry=geometry_column)
+        else:
+            return gpd.GeoDataFrame(), {}
 
         return gdf, {"token": pagination.get_next_token(offset + len(gdf))}
 

--- a/eia/generators/boson/provider.py
+++ b/eia/generators/boson/provider.py
@@ -175,6 +175,10 @@ class EIAGenerators:
         else:
             return gpd.GeoDataFrame(), {}
 
+        # Convert all numeric cols to numeric
+        for col in gdf.columns:
+            gdf[col] = pd.to_numeric(gdf[col], errors="ignore")
+
         return gdf, {"token": pagination.get_next_token(offset + len(gdf))}
 
     def update_facets(self, x_params: dict, filter: dict):

--- a/eia/power/boson/provider.py
+++ b/eia/power/boson/provider.py
@@ -131,8 +131,15 @@ class EIAElectricity:
 
         # Create the dataframe from the results
         data = response.get("data", [])
-        gdf = gpd.GeoDataFrame(data)
-        gdf.loc[:, "period"] = pd.to_datetime(gdf.period, utc=True)
+        if data:
+            gdf = gpd.GeoDataFrame(data)
+            gdf.loc[:, "period"] = pd.to_datetime(gdf.period, utc=True)
+        else:
+            return gpd.GeoDataFrame(), {}
+
+        # Convert all numeric cols to numeric
+        for col in gdf.columns:
+            gdf[col] = pd.to_numeric(gdf[col], errors="ignore")
 
         return gdf, {"token": pagination.get_next_token(offset + len(gdf))}
 


### PR DESCRIPTION
Added code to fix two bugs:
1) The provider was failing when empty data was returned due to a line that set the "period" column datatype. The provider now checks to see if the response is empty first. If empty, it returns an empty dataframe. If not, it assigns the "period"column datatype.
2) Numeric columns were being output as "object" columns, which was causing downstream problems in AGOL. Now the provider iterates over columns and does `pd.to_numeric` on each, ignoring errors and keeping non-numeric columns the same